### PR TITLE
Added 'like a recommendation' endpoint and its corresponding tests

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -270,6 +270,34 @@ def link_recommendation_product(recommendation_id, recommend_product_id):
     return jsonify(recommendation.serialize()), status.HTTP_200_OK
 
 
+@app.route("/recommendations/<int:recommendation_id>/like", methods=["PATCH"])
+def like_recommendation(recommendation_id):
+    """
+    Like a recommendation
+    This endpoint will increase the success count (rec_success) of a recommendation
+    """
+    app.logger.info("Request to like recommendation with id: %d", recommendation_id)
+
+    recommendation = Recommendation.find(recommendation_id)
+    if not recommendation:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Recommendation with id '{recommendation_id}' was not found.",
+        )
+
+    # Increment the recommendation success counter
+    recommendation.rec_success += 1
+    recommendation.update()
+
+    app.logger.info(
+        "Recommendation %d liked, success count increased to %d",
+        recommendation_id,
+        recommendation.rec_success,
+    )
+
+    return jsonify(recommendation.serialize()), status.HTTP_200_OK
+
+
 ######################################################################
 #  DELETE A RECOMMENDATION
 ######################################################################

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -431,7 +431,6 @@ class TestRecommendationService(TestCase):
     # ----------------------------------------------------------
     # TEST LINK
     # ----------------------------------------------------------
-
     def test_link_recommendation_product(self):
         """It should link a recommendation to a new recommended product"""
         # Create a recommendation first
@@ -463,38 +462,36 @@ class TestRecommendationService(TestCase):
         response = self.client.put(f"{BASE_URL}/9999/link/1234")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-           # Add after test_link_recommendation_not_found and before test_list_with_all_filters
-    
+        # Add after test_link_recommendation_not_found and before test_list_with_all_filters
+
     # ----------------------------------------------------------
     # TEST LIKE
     # ----------------------------------------------------------
-    
+
     def test_like_recommendation(self):
         """It should like a recommendation and increase its success count"""
         # Create a recommendation first
         recommendation = RecommendationFactory()
         response = self.client.post(BASE_URL, json=recommendation.serialize())
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-    
+
         # Fetch the created recommendation
         new_recommendation = response.get_json()
         initial_success = new_recommendation["rec_success"]
-        
+
         # Like the recommendation
         like_url = f"{BASE_URL}/{new_recommendation['id']}/like"
         response = self.client.patch(like_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        
+
         # Check that rec_success was incremented
         updated_recommendation = response.get_json()
         self.assertEqual(updated_recommendation["rec_success"], initial_success + 1)
-    
+
     def test_like_recommendation_not_found(self):
         """It should return 404 when liking a non-existent recommendation"""
         response = self.client.patch(f"{BASE_URL}/9999/like")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
-
 
     def test_list_with_all_filters(self):
         """It should handle all filters in list recommendations"""

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -463,6 +463,39 @@ class TestRecommendationService(TestCase):
         response = self.client.put(f"{BASE_URL}/9999/link/1234")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+           # Add after test_link_recommendation_not_found and before test_list_with_all_filters
+    
+    # ----------------------------------------------------------
+    # TEST LIKE
+    # ----------------------------------------------------------
+    
+    def test_like_recommendation(self):
+        """It should like a recommendation and increase its success count"""
+        # Create a recommendation first
+        recommendation = RecommendationFactory()
+        response = self.client.post(BASE_URL, json=recommendation.serialize())
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+    
+        # Fetch the created recommendation
+        new_recommendation = response.get_json()
+        initial_success = new_recommendation["rec_success"]
+        
+        # Like the recommendation
+        like_url = f"{BASE_URL}/{new_recommendation['id']}/like"
+        response = self.client.patch(like_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        # Check that rec_success was incremented
+        updated_recommendation = response.get_json()
+        self.assertEqual(updated_recommendation["rec_success"], initial_success + 1)
+    
+    def test_like_recommendation_not_found(self):
+        """It should return 404 when liking a non-existent recommendation"""
+        response = self.client.patch(f"{BASE_URL}/9999/like")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+
     def test_list_with_all_filters(self):
         """It should handle all filters in list recommendations"""
         test_recommendation = self._create_recommendations(1)[0]


### PR DESCRIPTION
**Summary**
This PR implements a new action route that allows users to "like" a recommendation, which increases the recommendation's success rate counter (rec_success). This meets the requirements specified in the Kanban story.

**Implementation** **Details**
Added a new PATCH endpoint at /recommendations/{id}/like
The endpoint increases the rec_success counter of the specified recommendation
Returns 404 Not Found if the recommendation doesn't exist
Returns the updated recommendation in the response

**Testing**
Added two new test cases:
test_like_recommendation: Tests that the success counter is incremented correctly
test_like_recommendation_not_found: Tests error handling for non-existent recommendations
All tests pass with 95.69% code coverage (above the required 95% threshold)

**Acceptance** **Criteria** **Met**
✅ Users can update the success rate of a recommendation through the "like" action
✅ The API correctly returns 404 for non-existent recommendations
✅ The implementation follows RESTful API best practices